### PR TITLE
fix: use fetch API for transcripts

### DIFF
--- a/packages/yt_bulk_cc/README.md
+++ b/packages/yt_bulk_cc/README.md
@@ -94,6 +94,7 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | `-c`, `--cookie-json`        | _(file)_        | Path to a cookies JSON file for accessing private/members-only content.                                                          |
 | `-s`, `--sleep`              | _(int)_         | Seconds to wait between pagination requests when scraping. Default: `2`.                                                         |
 | `--delay`                    | _(float)_       | Seconds to wait after each transcript download. |
+| `--bail-on-ip-block`         |                 | Abort immediately if YouTube returns 429/403. |
 | **Utilities**                |                 |                                                                                                                                  |
 | `--convert`                  | _(path)_        | Converts existing JSON transcripts from a file or directory to the specified `-f` format.                                        |
 | `--overwrite`                |                 | Re-download and overwrite files even if they already exist.                                                                      |

--- a/packages/yt_bulk_cc/README.md
+++ b/packages/yt_bulk_cc/README.md
@@ -93,6 +93,7 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | `-p`, `--proxy`              | _(url)_         | A single proxy URL or a comma-separated list to rotate through.                                                                  |
 | `-c`, `--cookie-json`        | _(file)_        | Path to a cookies JSON file for accessing private/members-only content.                                                          |
 | `-s`, `--sleep`              | _(int)_         | Seconds to wait between pagination requests when scraping. Default: `2`.                                                         |
+| `--delay`                    | _(float)_       | Seconds to wait after each transcript download. |
 | **Utilities**                |                 |                                                                                                                                  |
 | `--convert`                  | _(path)_        | Converts existing JSON transcripts from a file or directory to the specified `-f` format.                                        |
 | `--overwrite`                |                 | Re-download and overwrite files even if they already exist.                                                                      |

--- a/packages/yt_bulk_cc/pyproject.toml
+++ b/packages/yt_bulk_cc/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "urllib3>=2.4.0",
     "uvloop>=0.21.0",
     "youtube-transcript-api>=1.1.1",
+    "fake-useragent>=2.2",
 ]
 
 [project.scripts]

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/__init__.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/__init__.py
@@ -57,6 +57,7 @@ from .errors import (
     TooManyRequests,
 )  # noqa: E402
 from .core import grab, video_iter  # noqa: E402
+from .user_agent import _pick_ua  # noqa: E402
 
 globals().update({
     "slug": slug,
@@ -75,12 +76,14 @@ globals().update({
     "TooManyRequests": TooManyRequests,
     "grab": grab,
     "video_iter": video_iter,
+    "_pick_ua": _pick_ua,
 })
 
 # Keep __all__ accurate
 __all__ = sorted(set(__all__) | {
     "slug", "_stats", "detect", "_shorten_for_windows", "TimeStampedText", "FMT", "EXT", "convert_existing", "CouldNotRetrieveTranscript", "NoTranscriptFound", "TranscriptsDisabled", "VideoUnavailable", "NoTranscriptAvailable", "TooManyRequests", "grab", "video_iter"
-}) 
+    , "_pick_ua",
+})
 
 # ---------------------------------------------------------------------------
 # Make asyncio.run tolerant when already inside a running event loop.

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
@@ -13,6 +13,7 @@ from random import choice
 from typing import Sequence
 import requests
 from youtube_transcript_api.proxies import GenericProxyConfig
+from .user_agent import _pick_ua
 
 import scrapetube
 from youtube_transcript_api import YouTubeTranscriptApi
@@ -58,7 +59,7 @@ async def grab(
                     proxy = GenericProxyConfig(http_url=url, https_url=url)
 
                 session = requests.Session()
-                session.headers.update({"User-Agent": "Mozilla/5.0"})
+                session.headers.update({"User-Agent": _pick_ua()})
                 if cookies:
                     for c in cookies:
                         session.cookies.set(c.get("name"), c.get("value"))

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
@@ -57,9 +57,9 @@ async def grab(
                     url = proxy_pool[0] if len(proxy_pool) == 1 else choice(proxy_pool)
                     proxy = GenericProxyConfig(http_url=url, https_url=url)
 
-                session = None
+                session = requests.Session()
+                session.headers.update({"User-Agent": "Mozilla/5.0"})
                 if cookies:
-                    session = requests.Session()
                     for c in cookies:
                         session.cookies.set(c.get("name"), c.get("value"))
 

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import random
 from typing import Final
@@ -12,11 +11,6 @@ USER_AGENTS_POOL: Final[list[str]] = ["fallback-ua"]
 
 def _pick_ua(browser: str | None = None, os: str | None = None) -> str:
     """Return a plausible User-Agent string."""
-    ua_is_mock = not inspect.isclass(UserAgent)
-
-    if browser is None and os is None and not ua_is_mock:
-        return random.choice(USER_AGENTS_POOL)
-
     try:
         ua_src = UserAgent(browsers=[browser] if browser else None,
                            os=[os] if os else None)
@@ -24,3 +18,4 @@ def _pick_ua(browser: str | None = None, os: str | None = None) -> str:
     except Exception as exc:  # noqa: BLE001
         logging.warning("fake-useragent failed (%s) - using fallback UA", exc)
         return random.choice(USER_AGENTS_POOL)
+

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import random
+from typing import Final
+
+from fake_useragent import UserAgent
+
+USER_AGENTS_POOL: Final[list[str]] = ["fallback-ua"]
+
+
+def _pick_ua(browser: str | None = None, os: str | None = None) -> str:
+    """Return a plausible User-Agent string."""
+    ua_is_mock = not inspect.isclass(UserAgent)
+
+    if browser is None and os is None and not ua_is_mock:
+        return random.choice(USER_AGENTS_POOL)
+
+    try:
+        ua_src = UserAgent(browsers=[browser] if browser else None,
+                           os=[os] if os else None)
+        return ua_src.random
+    except Exception as exc:  # noqa: BLE001
+        logging.warning("fake-useragent failed (%s) - using fallback UA", exc)
+        return random.choice(USER_AGENTS_POOL)

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -378,9 +378,9 @@ async def grab(
                     url = proxy_pool[0] if len(proxy_pool) == 1 else choice(proxy_pool)
                     proxy = GenericProxyConfig(http_url=url, https_url=url)
 
-                session = None
+                session = requests.Session()
+                session.headers.update({"User-Agent": "Mozilla/5.0"})
                 if cookies:
-                    session = requests.Session()
                     for c in cookies:
                         session.cookies.set(c.get("name"), c.get("value"))
 

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -30,7 +30,6 @@ import asyncio
 import contextlib
 import datetime
 import os            # NEW - Windows pathname tweak
-import inspect
 import json
 import logging
 import re
@@ -46,6 +45,8 @@ from typing import Sequence
 
 import scrapetube
 from youtube_transcript_api import YouTubeTranscriptApi, formatters
+from youtube_transcript_api.proxies import GenericProxyConfig
+import requests
 # ------------------------------------------------------------
 #  Robust error-class import — works on every library version
 # ------------------------------------------------------------
@@ -371,28 +372,25 @@ async def grab(
     async with sem:
         for attempt in range(1, tries + 1):
             try:
-                # build kwargs only with supported keys
-                sig_params = inspect.signature(
-                    YouTubeTranscriptApi.get_transcript
-                ).parameters
-                kwargs = {}
-                if langs and "languages" in sig_params:
-                    kwargs["languages"] = list(langs)
-                if proxy_pool and "proxies" in sig_params:
+                proxy = None
+                if proxy_pool:
                     url = proxy_pool[0] if len(proxy_pool) == 1 else choice(proxy_pool)
-                    kwargs["proxies"] = {"http": url, "https": url}
-                if cookies and "cookies" in sig_params:
-                    kwargs["cookies"] = cookies
+                    proxy = GenericProxyConfig(http_url=url, https_url=url)
 
-                
+                session = None
+                if cookies:
+                    session = requests.Session()
+                    for c in cookies:
+                        session.cookies.set(c.get("name"), c.get("value"))
 
+                api = YouTubeTranscriptApi(proxy_config=proxy, http_client=session)
 
-                # returns a list of dicts
                 tr = await asyncio.to_thread(
-                    YouTubeTranscriptApi.get_transcript,
+                    api.fetch,
                     vid,
-                    **kwargs,
+                    languages=list(langs) if langs else ["en"],
                 )
+                tr = tr.to_raw_data()
 
                 meta = {
                     "video_id": vid,

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -47,6 +47,7 @@ import scrapetube
 from youtube_transcript_api import YouTubeTranscriptApi, formatters
 from youtube_transcript_api.proxies import GenericProxyConfig
 import requests
+from .user_agent import _pick_ua
 # ------------------------------------------------------------
 #  Robust error-class import — works on every library version
 # ------------------------------------------------------------
@@ -379,7 +380,7 @@ async def grab(
                     proxy = GenericProxyConfig(http_url=url, https_url=url)
 
                 session = requests.Session()
-                session.headers.update({"User-Agent": "Mozilla/5.0"})
+                session.headers.update({"User-Agent": _pick_ua()})
                 if cookies:
                     for c in cookies:
                         session.cookies.set(c.get("name"), c.get("value"))

--- a/packages/yt_bulk_cc/tests/test_user_agent.py
+++ b/packages/yt_bulk_cc/tests/test_user_agent.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from yt_bulk_cc.user_agent import _pick_ua
+
+
+def test_ua_browser_filter():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua(browser="chrome")
+        assert "Chrome" in ua
+        mock_cls.assert_called_once_with(browsers=["chrome"], os=None)
+
+
+def test_ua_os_filter():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua(os="windows")
+        assert "Windows" in ua
+        mock_cls.assert_called_once_with(browsers=None, os=["windows"])
+
+
+def test_ua_fallback():
+    def mock_init(*args, **kwargs):
+        raise Exception("Network error")
+
+    with patch('yt_bulk_cc.user_agent.UserAgent.__init__', side_effect=mock_init):
+        with patch('random.choice', return_value="fallback-ua") as mock_choice:
+            ua = _pick_ua()
+            assert ua == "fallback-ua"
+            mock_choice.assert_called_once()
+
+
+def test_ua_no_filters():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua()
+        assert ua is not None
+        mock_cls.assert_called_once_with(browsers=None, os=None)
+
+
+
+def test_ua_invoked_when_unpatched(monkeypatch):
+    called = {}
+    class DummyUA:
+        def __init__(self, *a, **kw):
+            called['kw'] = kw
+        @property
+        def random(self):
+            return 'dummy-UA'
+    monkeypatch.setattr('yt_bulk_cc.user_agent.UserAgent', DummyUA)
+    ua = _pick_ua()
+    assert ua == 'dummy-UA'
+    assert called['kw'] == {'browsers': None, 'os': None}

--- a/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
@@ -820,6 +820,7 @@ def test_default_user_agent(monkeypatch, tmp_path: Path):
     """grab() should use a sensible User-Agent header by default."""
 
     monkeypatch.setattr(ytb, "detect", lambda _u: ("video", "vidX"))
+    monkeypatch.setattr(ytb, "_pick_ua", lambda *_a, **_k: "UA/123")
 
     captured = {}
 
@@ -838,4 +839,4 @@ def test_default_user_agent(monkeypatch, tmp_path: Path):
 
     run_cli(tmp_path, "https://youtu.be/vidX")
 
-    assert captured["ua"].startswith("Mozilla"), "User-Agent not set"
+    assert captured["ua"] == "UA/123"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,6 +1224,7 @@ source = { editable = "packages/yt_bulk_cc" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
+    { name = "fake-useragent" },
     { name = "idna" },
     { name = "requests" },
     { name = "rich" },
@@ -1238,6 +1239,7 @@ dependencies = [
 requires-dist = [
     { name = "certifi", specifier = ">=2025.6.15" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
+    { name = "fake-useragent", specifier = ">=2.2" },
     { name = "idna", specifier = ">=3.10" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.0.0" },


### PR DESCRIPTION
## Summary
- handle updated youtube-transcript-api by using `fetch`
- update proxy/cookie handling for new API
- adjust tests to mock `fetch`

## Testing
- `./scripts/test-ybc`

------
https://chatgpt.com/codex/tasks/task_e_686b4147dc98832d9f9b226bd40dff93