### PR TITLE
feat: IP probe and file-based proxy/cookie options

### DIFF
--- a/packages/yt_bulk_cc/README.md
+++ b/packages/yt_bulk_cc/README.md
@@ -93,8 +93,7 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | `-p`, `--proxy`              | _(url)_         | A single proxy URL or a comma-separated list to rotate through.                                                                  |
 | `--proxy-file`              | _(file)_        | Load proxies from a file (one URL per line). |
 | `-c`, `--cookie-json`, `--cookie-file`        | _(file)_        | Cookies JSON exported by your browser. |
-| `-s`, `--sleep`              | _(int)_         | Seconds to wait between pagination requests when scraping. Default: `2`.                                                         |
-| `--delay`                    | _(float)_       | Seconds to wait after each transcript download. |
+| `-s`, `--sleep`              | _(float)_       | Seconds to wait between playlist requests and after each transcript. Default: `2`. |
 | `--check-ip`                |                 | Preflight transcript fetch to detect IP bans before downloading. |
 | **Utilities**                |                 |                                                                                                                                  |
 | `--convert`                  | _(path)_        | Converts existing JSON transcripts from a file or directory to the specified `-f` format.                                        |
@@ -104,6 +103,12 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | `--no-log`                   |                 | Disable file logging entirely.                                                                                                   |
 | `-F`, `--formats-help`       |                 | Show examples of each output format and exit.                                                                                    |
 
+### Exporting cookies
+
+Use a browser extension like **Get cookies.txt** for Chrome or Firefox:
+1. Log into YouTube in your browser.
+2. Use the extension to export cookies for `youtube.com` as JSON.
+3. Pass this file with `-c cookies.json`.
 ---
 
 ## License

--- a/packages/yt_bulk_cc/README.md
+++ b/packages/yt_bulk_cc/README.md
@@ -92,7 +92,7 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | **Network & Authentication** |                 |                                                                                                                                  |
 | `-p`, `--proxy`              | _(url)_         | A single proxy URL or a comma-separated list to rotate through.                                                                  |
 | `--proxy-file`              | _(file)_        | Load proxies from a file (one URL per line). |
-| `-c`, `--cookie-json`, `--cookie-file`        | _(file)_        | Cookies JSON exported by your browser. |
+| `-c`, `--cookie-json`, `--cookie-file`        | _(file)_        | Cookies JSON exported with a browser extension (see below). |
 | `-s`, `--sleep`              | _(float)_       | Seconds to wait between playlist requests and after each transcript. Default: `2`. |
 | `--check-ip`                |                 | Preflight transcript fetch to detect IP bans before downloading. |
 | **Utilities**                |                 |                                                                                                                                  |
@@ -107,8 +107,8 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 
 Use a browser extension like **Get cookies.txt** for Chrome or Firefox:
 1. Log into YouTube in your browser.
-2. Use the extension to export cookies for `youtube.com` as JSON.
-3. Pass this file with `-c cookies.json`.
+2. Choose **Export as JSON** for `youtube.com` in the extension menu.
+3. Save the file (e.g. `cookies.json`) and pass it with `-c cookies.json`.
 ---
 
 ## License

--- a/packages/yt_bulk_cc/README.md
+++ b/packages/yt_bulk_cc/README.md
@@ -91,8 +91,11 @@ python -m yt_bulk_cc.yt_bulk_cc --convert ./out -f srt -o ./out_srt
 | `--split`                    | _(e.g. 10000c)_ | With `--concat`, splits the output into new files when a size threshold is met.<br>Units: `w` (words), `l` (lines), `c` (chars). |
 | **Network & Authentication** |                 |                                                                                                                                  |
 | `-p`, `--proxy`              | _(url)_         | A single proxy URL or a comma-separated list to rotate through.                                                                  |
-| `-c`, `--cookie-json`        | _(file)_        | Path to a cookies JSON file for accessing private/members-only content.                                                          |
+| `--proxy-file`              | _(file)_        | Load proxies from a file (one URL per line). |
+| `-c`, `--cookie-json`, `--cookie-file`        | _(file)_        | Cookies JSON exported by your browser. |
 | `-s`, `--sleep`              | _(int)_         | Seconds to wait between pagination requests when scraping. Default: `2`.                                                         |
+| `--delay`                    | _(float)_       | Seconds to wait after each transcript download. |
+| `--check-ip`                |                 | Preflight transcript fetch to detect IP bans before downloading. |
 | **Utilities**                |                 |                                                                                                                                  |
 | `--convert`                  | _(path)_        | Converts existing JSON transcripts from a file or directory to the specified `-f` format.                                        |
 | `--overwrite`                |                 | Re-download and overwrite files even if they already exist.                                                                      |

--- a/packages/yt_bulk_cc/pyproject.toml
+++ b/packages/yt_bulk_cc/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "urllib3>=2.4.0",
     "uvloop>=0.21.0",
     "youtube-transcript-api>=1.1.1",
+    "fake-useragent>=2.2",
 ]
 
 [project.scripts]

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/__init__.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/__init__.py
@@ -56,7 +56,8 @@ from .errors import (
     NoTranscriptAvailable,
     TooManyRequests,
 )  # noqa: E402
-from .core import grab, video_iter  # noqa: E402
+from .core import grab, video_iter, probe_video  # noqa: E402
+from .user_agent import _pick_ua  # noqa: E402
 
 globals().update({
     "slug": slug,
@@ -75,12 +76,15 @@ globals().update({
     "TooManyRequests": TooManyRequests,
     "grab": grab,
     "video_iter": video_iter,
+    "probe_video": probe_video,
+    "_pick_ua": _pick_ua,
 })
 
 # Keep __all__ accurate
 __all__ = sorted(set(__all__) | {
     "slug", "_stats", "detect", "_shorten_for_windows", "TimeStampedText", "FMT", "EXT", "convert_existing", "CouldNotRetrieveTranscript", "NoTranscriptFound", "TranscriptsDisabled", "VideoUnavailable", "NoTranscriptAvailable", "TooManyRequests", "grab", "video_iter"
-}) 
+    , "probe_video", "_pick_ua",
+})
 
 # ---------------------------------------------------------------------------
 # Make asyncio.run tolerant when already inside a running event loop.

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/core.py
@@ -7,11 +7,13 @@ other modules to keep responsibilities clear.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 from pathlib import Path
 from random import choice
 from typing import Sequence
+import requests
+from youtube_transcript_api.proxies import GenericProxyConfig
+from .user_agent import _pick_ua
 
 import scrapetube
 from youtube_transcript_api import YouTubeTranscriptApi
@@ -30,7 +32,36 @@ from . import _single_file_header, _fixup_loop  # type: ignore
 __all__ = [
     "grab",
     "video_iter",
+    "probe_video",
 ]
+
+
+def probe_video(
+    vid: str,
+    *,
+    cookies: list | None = None,
+    proxy_pool: list[str] | None = None,
+) -> bool:
+    """Return ``True`` if ``vid`` can be fetched without IP blocks."""
+    proxy = None
+    if proxy_pool:
+        url = proxy_pool[0] if len(proxy_pool) == 1 else choice(proxy_pool)
+        proxy = GenericProxyConfig(http_url=url, https_url=url)
+
+    session = requests.Session()
+    session.headers.update({"User-Agent": _pick_ua()})
+    if cookies:
+        for c in cookies:
+            session.cookies.set(c.get("name"), c.get("value"))
+
+    api = YouTubeTranscriptApi(proxy_config=proxy, http_client=session)
+    try:
+        api.fetch(vid, languages=["en"]).to_raw_data()
+    except (TooManyRequests, IpBlocked):
+        return False
+    except Exception:
+        return True
+    return True
 
 
 async def grab(
@@ -45,28 +76,31 @@ async def grab(
     cookies: list | None = None,
     proxy_pool: list[str] | None = None,
     include_stats: bool = True,
+    delay: float = 0.0,
 ):
     """Download a single transcript asynchronously and write it to *path*."""
     async with sem:
         for attempt in range(1, tries + 1):
             try:
-                sig_params = inspect.signature(
-                    YouTubeTranscriptApi.get_transcript
-                ).parameters
-                kwargs: dict = {}
-                if langs and "languages" in sig_params:
-                    kwargs["languages"] = list(langs)
-                if proxy_pool and "proxies" in sig_params:
+                proxy = None
+                if proxy_pool:
                     url = proxy_pool[0] if len(proxy_pool) == 1 else choice(proxy_pool)
-                    kwargs["proxies"] = {"http": url, "https": url}
-                if cookies and "cookies" in sig_params:
-                    kwargs["cookies"] = cookies
+                    proxy = GenericProxyConfig(http_url=url, https_url=url)
+
+                session = requests.Session()
+                session.headers.update({"User-Agent": _pick_ua()})
+                if cookies:
+                    for c in cookies:
+                        session.cookies.set(c.get("name"), c.get("value"))
+
+                api = YouTubeTranscriptApi(proxy_config=proxy, http_client=session)
 
                 tr = await asyncio.to_thread(
-                    YouTubeTranscriptApi.get_transcript,
+                    api.fetch,
                     vid,
-                    **kwargs,
+                    languages=list(langs) if langs else ["en"],
                 )
+                tr = tr.to_raw_data()
 
                 meta = {
                     "video_id": vid,
@@ -101,20 +135,30 @@ async def grab(
                     full = _single_file_header(fmt_key, data, meta)  # type: ignore[arg-type]
                     path.write_text(full, encoding="utf-8")
                 logging.info("✔ saved %s", path.name)
+                if delay:
+                    await asyncio.sleep(delay)
                 return ("ok", vid, title)
 
             except (TranscriptsDisabled, NoTranscriptFound):
                 logging.warning("No subtitles for video %s", vid)
+                if delay:
+                    await asyncio.sleep(delay)
                 return ("none", vid, title)
             except (TooManyRequests, IpBlocked, CouldNotRetrieveTranscript) as exc:
                 wait = 6 * attempt
                 logging.info("⏳ %s - retrying in %ss (attempt %s/%s)",
-                             exc.__class__.__name__, wait, attempt, tries)
+                    exc.__class__.__name__,
+                    wait,
+                    attempt,
+                    tries,
+                )
                 await asyncio.sleep(wait)
                 continue
             except Exception as exc:
                 if attempt == tries:
                     logging.error("%s after %d tries – giving up", exc, attempt)
+                    if delay:
+                        await asyncio.sleep(delay)
                     return ("fail", vid, title)
                 await asyncio.sleep(0.5 * attempt)
 

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/user_agent.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import Final
+
+from fake_useragent import UserAgent
+
+USER_AGENTS_POOL: Final[list[str]] = ["fallback-ua"]
+
+
+def _pick_ua(browser: str | None = None, os: str | None = None) -> str:
+    """Return a plausible User-Agent string."""
+    try:
+        ua_src = UserAgent(browsers=[browser] if browser else None,
+                           os=[os] if os else None)
+        return ua_src.random
+    except Exception as exc:  # noqa: BLE001
+        logging.warning("fake-useragent failed (%s) - using fallback UA", exc)
+        return random.choice(USER_AGENTS_POOL)
+

--- a/packages/yt_bulk_cc/tests/test_user_agent.py
+++ b/packages/yt_bulk_cc/tests/test_user_agent.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from yt_bulk_cc.user_agent import _pick_ua
+
+
+def test_ua_browser_filter():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua(browser="chrome")
+        assert "Chrome" in ua
+        mock_cls.assert_called_once_with(browsers=["chrome"], os=None)
+
+
+def test_ua_os_filter():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua(os="windows")
+        assert "Windows" in ua
+        mock_cls.assert_called_once_with(browsers=None, os=["windows"])
+
+
+def test_ua_fallback():
+    def mock_init(*args, **kwargs):
+        raise Exception("Network error")
+
+    with patch('yt_bulk_cc.user_agent.UserAgent.__init__', side_effect=mock_init):
+        with patch('random.choice', return_value="fallback-ua") as mock_choice:
+            ua = _pick_ua()
+            assert ua == "fallback-ua"
+            mock_choice.assert_called_once()
+
+
+def test_ua_no_filters():
+    mock_ua = MagicMock()
+    mock_ua.random = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/123.0.0.0"
+    with patch('yt_bulk_cc.user_agent.UserAgent', return_value=mock_ua) as mock_cls:
+        ua = _pick_ua()
+        assert ua is not None
+        mock_cls.assert_called_once_with(browsers=None, os=None)
+
+
+
+def test_ua_invoked_when_unpatched(monkeypatch):
+    called = {}
+    class DummyUA:
+        def __init__(self, *a, **kw):
+            called['kw'] = kw
+        @property
+        def random(self):
+            return 'dummy-UA'
+    monkeypatch.setattr('yt_bulk_cc.user_agent.UserAgent', DummyUA)
+    ua = _pick_ua()
+    assert ua == 'dummy-UA'
+    assert called['kw'] == {'browsers': None, 'os': None}

--- a/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
@@ -1,7 +1,7 @@
 """
 End-to-end and unit-level tests for yt_bulk_cc.py.
 
-A strict no-network policy is enforced:  YouTubeTranscriptApi.get_transcript,
+A strict no-network policy is enforced:  YouTubeTranscriptApi.fetch,
 scrapetube.get_playlist / get_channel, and the detect() helper are patched with
 in-memory stubs so the suite can run anywhere (CI, air-gapped laptop, etc.).
 
@@ -47,11 +47,20 @@ def fake_cues():
 
 @pytest.fixture
 def patch_transcript(monkeypatch, fake_cues):
-    """Stub out YouTubeTranscriptApi.get_transcript."""
+    """Stub out YouTubeTranscriptApi.fetch."""
     class _FakeApi:
-        @staticmethod
-        def get_transcript(*_, **__):
-            return fake_cues
+        def __init__(self, *a, **kw):
+            pass
+
+        def fetch(self, *_, **__):
+            class _FT:
+                def __init__(self, data):
+                    self._data = data
+
+                def to_raw_data(self):
+                    return self._data
+
+            return _FT(fake_cues)
 
     monkeypatch.setattr(ytb, "YouTubeTranscriptApi", _FakeApi)
     yield
@@ -235,8 +244,10 @@ def test_convert_concat_json(tmp_path: Path, dest_fmt):
 def test_no_caption_flow(monkeypatch, tmp_path):
     """Patch API to raise NoTranscriptFound and ensure graceful summary."""
     class _NoneApi:
-        @staticmethod
-        def get_transcript(video_id, *_, **__):
+        def __init__(self, *a, **kw):
+            pass
+
+        def fetch(self, video_id, *_, **__):
             # Must instantiate with the video_id (mimics real library).
             raise ytb.NoTranscriptFound(video_id)
 
@@ -717,18 +728,25 @@ def test_retry_too_many_requests(monkeypatch, tmp_path: Path, capsys):
 
     calls = {"n": 0}
 
-    def _fake_get_transcript(*_a, **_kw):
+    def _fake_fetch(*_a, **_kw):
         calls["n"] += 1
         if calls["n"] < 3:  # first two attempts → fail
             raise ytb.TooManyRequests("slow down")
         # third attempt → return minimal cue
-        return [{"start": 0.0, "duration": 1.0, "text": "OK"}]
+        class _FT:
+            def to_raw_data(self):
+                return [{"start": 0.0, "duration": 1.0, "text": "OK"}]
 
-    monkeypatch.setattr(
-        ytb,
-        "YouTubeTranscriptApi",
-        type("FakeApi", (), {"get_transcript": staticmethod(_fake_get_transcript)}),
-    )
+        return _FT()
+
+    class _FakeApi:
+        def __init__(self, *a, **kw):
+            pass
+
+        def fetch(self, *a, **kw):
+            return _fake_fetch(*a, **kw)
+
+    monkeypatch.setattr(ytb, "YouTubeTranscriptApi", _FakeApi)
 
     # -v → console log level INFO so the retry line reaches stdout
     run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "-v")
@@ -746,18 +764,25 @@ def test_retry_ip_blocked(monkeypatch, tmp_path: Path, capsys):
 
     calls = {"n": 0}
 
-    def _fake_get_transcript(*_a, **_kw):
+    def _fake_fetch(*_a, **_kw):
         calls["n"] += 1
         if calls["n"] < 3:  # first two attempts → fail
             raise ytb.IpBlocked("IP blocked")
         # third attempt → return minimal cue
-        return [{"start": 0.0, "duration": 1.0, "text": "OK"}]
+        class _FT:
+            def to_raw_data(self):
+                return [{"start": 0.0, "duration": 1.0, "text": "OK"}]
 
-    monkeypatch.setattr(
-        ytb,
-        "YouTubeTranscriptApi",
-        type("FakeApi", (), {"get_transcript": staticmethod(_fake_get_transcript)}),
-    )
+        return _FT()
+
+    class _FakeApi:
+        def __init__(self, *a, **kw):
+            pass
+
+        def fetch(self, *a, **kw):
+            return _fake_fetch(*a, **kw)
+
+    monkeypatch.setattr(ytb, "YouTubeTranscriptApi", _FakeApi)
 
     # -v → console log level INFO so the retry line reaches stdout
     run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "-v")
@@ -767,6 +792,26 @@ def test_retry_ip_blocked(monkeypatch, tmp_path: Path, capsys):
 
     # We should have attempted exactly three calls (two IpBlocked + final success)
     assert calls["n"] == 3, "back-off logic did not retry the expected number of times"
+
+
+@pytest.mark.usefixtures("patch_scrapetube", "patch_detect")
+def test_check_ip_bails(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr("yt_bulk_cc.core.probe_video", lambda *a, **k: False)
+    with pytest.raises(SystemExit):
+        run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "--check-ip")
+
+
+@pytest.mark.usefixtures("patch_scrapetube", "patch_detect")
+def test_check_ip_ok(monkeypatch, tmp_path: Path, patch_transcript):
+    called = {"n": 0}
+
+    def probe(*a, **k):
+        called["n"] += 1
+        return True
+
+    monkeypatch.setattr("yt_bulk_cc.core.probe_video", probe)
+    run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "--check-ip")
+    assert called["n"] == 1
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -785,3 +830,33 @@ def test_windows_path_shortening(monkeypatch, tmp_path: Path):
 
     shortened = ytb._shorten_for_windows(original)
     assert len(str(shortened)) <= 260, "path exceeds Windows MAX_PATH"
+
+
+# ---------------------------------------------------------------------------
+# 3. Ensure grab() uses a browser-like User-Agent
+# ---------------------------------------------------------------------------
+
+def test_default_user_agent(monkeypatch, tmp_path: Path):
+    """grab() should use a sensible User-Agent header by default."""
+
+    monkeypatch.setattr(ytb, "detect", lambda _u: ("video", "vidX"))
+    monkeypatch.setattr(ytb, "_pick_ua", lambda *_a, **_k: "UA/123")
+
+    captured = {}
+
+    class _FakeApi:
+        def __init__(self, *_, **kw):
+            captured["ua"] = kw.get("http_client").headers.get("User-Agent")
+
+        def fetch(self, *a, **kw):
+            class _FT:
+                def to_raw_data(self):
+                    return [{"start": 0.0, "duration": 1.0, "text": "hi"}]
+
+            return _FT()
+
+    monkeypatch.setattr(ytb, "YouTubeTranscriptApi", _FakeApi)
+
+    run_cli(tmp_path, "https://youtu.be/vidX")
+
+    assert captured["ua"] == "UA/123"

--- a/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
@@ -795,10 +795,16 @@ def test_retry_ip_blocked(monkeypatch, tmp_path: Path, capsys):
 
 
 @pytest.mark.usefixtures("patch_scrapetube", "patch_detect")
-def test_check_ip_bails(monkeypatch, tmp_path: Path):
-    monkeypatch.setattr("yt_bulk_cc.core.probe_video", lambda *a, **k: False)
+def test_check_ip_bails(monkeypatch, tmp_path: Path, capsys):
+    monkeypatch.setattr(
+        "yt_bulk_cc.core.probe_video", lambda *a, **k: (False, {"p"})
+    )
     with pytest.raises(SystemExit):
-        run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "--check-ip")
+        run_cli(tmp_path, "dummy", "-f", "text", "-n", "2", "--check-ip")
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "Summary:" in out
+    assert "failed 2" in out
+    assert "banned 1" in out
 
 
 @pytest.mark.usefixtures("patch_scrapetube", "patch_detect")
@@ -807,7 +813,7 @@ def test_check_ip_ok(monkeypatch, tmp_path: Path, patch_transcript):
 
     def probe(*a, **k):
         called["n"] += 1
-        return True
+        return True, set()
 
     monkeypatch.setattr("yt_bulk_cc.core.probe_video", probe)
     run_cli(tmp_path, "dummy", "-f", "text", "-n", "1", "--check-ip")

--- a/uv.lock
+++ b/uv.lock
@@ -1224,6 +1224,7 @@ source = { editable = "packages/yt_bulk_cc" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
+    { name = "fake-useragent" },
     { name = "idna" },
     { name = "requests" },
     { name = "rich" },
@@ -1238,6 +1239,7 @@ dependencies = [
 requires-dist = [
     { name = "certifi", specifier = ">=2025.6.15" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
+    { name = "fake-useragent", specifier = ">=2.2" },
     { name = "idna", specifier = ">=3.10" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "rich", specifier = ">=14.0.0" },


### PR DESCRIPTION
## Summary
- allow loading proxy URLs from a file and alias `--cookie-file`
- add `--check-ip` option to bail early when IP is blocked
- implement `probe_video` helper for preflight checks
- export `probe_video` in package API
- test IP probe logic

## Testing
- `./scripts/test-ybc -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4147dc98832d9f9b226bd40dff93