### PR TITLE
Fix yt_bulk_cc concat glob duplication bug

### DIFF
--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -31,6 +31,7 @@ import contextlib
 import datetime
 import os            # NEW - Windows pathname tweak
 import json
+import glob
 import logging
 import re
 import signal
@@ -921,7 +922,8 @@ async def _main() -> None:
 
                 # ── locate the file regardless of an optional 00001-style prefix
                 try:
-                    src = next(out_dir.glob(f"*[{vid}]*.json"))
+                    pattern = f"*{glob.escape('[' + vid + ']')}*.json"
+                    src = next(out_dir.glob(pattern))
                 except StopIteration:
                     logging.warning("File for %s not found - prefix off?", vid)
                     continue
@@ -993,7 +995,8 @@ async def _main() -> None:
                 else:
                     continue
                 try:
-                    src = next(out_dir.glob(f"*[{vid}]*.{EXT[args.format]}"))
+                    pattern = f"*{glob.escape('[' + vid + ']')}*.{EXT[args.format]}"
+                    src = next(out_dir.glob(pattern))
                 except StopIteration:
                     logging.warning("File for %s not found - prefix off?", vid)
                     continue

--- a/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
@@ -165,6 +165,28 @@ def test_concat_with_split(tmp_path: Path, unit):
 
 
 @pytest.mark.usefixtures("patch_transcript", "patch_scrapetube", "patch_detect")
+def test_text_concat_unique_videos(tmp_path: Path):
+    """Concatenated text output should contain each video once in order."""
+    run_cli(
+        tmp_path,
+        "dummy",
+        "-f",
+        "text",
+        "-C",
+        "bundle",
+        "-n",
+        "3",
+    )
+    out = tmp_path / "bundle.txt"
+    data = out.read_text()
+    ids = [f"vid{i}" for i in range(3)]
+    for vid in ids:
+        assert data.count(vid) >= 1, f"{vid} missing in concat"
+    seps = [l for l in data.splitlines() if l.startswith("──── ")]
+    assert len(seps) == 3
+
+
+@pytest.mark.usefixtures("patch_transcript", "patch_scrapetube", "patch_detect")
 def test_json_concat_contains_meta_and_stats(tmp_path: Path):
     run_cli(
         tmp_path,
@@ -182,6 +204,24 @@ def test_json_concat_contains_meta_and_stats(tmp_path: Path):
     assert {"stats", "items"} <= data.keys()
     assert data["stats"]["words"] > 0
     assert len(data["items"]) == 3
+
+
+@pytest.mark.usefixtures("patch_transcript", "patch_scrapetube", "patch_detect")
+def test_json_concat_unique_videos(tmp_path: Path):
+    """Ensure concatenated JSON lists each video exactly once."""
+    run_cli(
+        tmp_path,
+        "dummy",
+        "-f",
+        "json",
+        "-C",
+        "combo",
+        "-n",
+        "3",
+    )
+    out = tmp_path / "combo.json"
+    vids = [item["video_id"] for item in json.loads(out.read_text())["items"]]
+    assert vids == [f"vid{i}" for i in range(3)]
 
 
 # ────────────────────────── converter  ─────────────────────────────────── #


### PR DESCRIPTION
## Summary
- fix glob patterns when concatenating files in yt_bulk_cc
- verify unique videos during concatenation
- add missing glob import
- test JSON and text concat for unique videos

## Testing
- `./scripts/test-ybc`

------
https://chatgpt.com/codex/tasks/task_e_686c34a94630832d987d8e9ec807c82d