### PR TITLE
Add public proxy support to site_downloader

### DIFF
--- a/packages/site_downloader/README.md
+++ b/packages/site_downloader/README.md
@@ -83,6 +83,9 @@ sdl batch urls.txt -f pdf -j 8
 - `--proxy http://host:port` - Use a single proxy
 - `--proxies "http://p1:port,http://p2:port"` - Rotate through multiple proxies (comma-separated)
 - `--proxy-file proxies.txt` - Load proxies from file (one per line)
+- `--public-proxy 5` - Fetch N free proxies via Swiftshadow or a SOCKS list
+- `--public-proxy-country CC,CC` - Restrict public proxies to these countries
+- `--public-proxy-type http|https|socks` - Protocol for public proxies
 - `--ua-browser chrome` - Filter user agents by browser (chrome/firefox/safari/edge)
 - `--ua-os windows` - Filter user agents by OS (windows/linux/macos/android/ios)
 - `--cookies-json '{"name":"value"}'` - Pass cookies as JSON string

--- a/packages/site_downloader/pyproject.toml
+++ b/packages/site_downloader/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "fake-useragent>=2.2",
   "fake-headers>=1.0",
   "aiofiles>=24.1.0",
+  "swiftshadow>=2.2",
+  "requests[socks]>=2.32.4",
 ]
 
 [tool.setuptools]

--- a/packages/site_downloader/src/site_downloader/batch_async.py
+++ b/packages/site_downloader/src/site_downloader/batch_async.py
@@ -23,6 +23,9 @@ async def grab_async(
     proxy: str | None = None,
     proxies: str | None = None,
     proxy_file: pathlib.Path | None = None,
+    public_proxy: int | None = None,
+    public_proxy_country: str | None = None,
+    public_proxy_type: str | None = None,
     headers: str | None = None,
     dark_mode: bool = False,
     viewport_width: int = 1280,
@@ -49,7 +52,14 @@ async def grab_async(
     out.parent.mkdir(parents=True, exist_ok=True)
 
     # --- network identity ------------------------------------------------- #
-    _proxy_cycle = proxy_pool(proxy, proxies, proxy_file)
+    _proxy_cycle = proxy_pool(
+        proxy,
+        proxies,
+        proxy_file,
+        public_proxy=public_proxy,
+        public_proxy_country=public_proxy_country,
+        public_proxy_type=public_proxy_type,
+    )
     jar = json.loads(cookies_json) if cookies_json else None
     if cookies_file and not jar:
         from site_downloader.session import load_cookie_file

--- a/packages/site_downloader/src/site_downloader/proxy.py
+++ b/packages/site_downloader/src/site_downloader/proxy.py
@@ -9,9 +9,18 @@ Returns an **infinite** iterator (cycle) of proxies or ``None``.
 
 from __future__ import annotations
 
+import asyncio
 import itertools
 import pathlib
+import requests
 from typing import Iterator, Optional
+from random import choice
+from threading import Thread
+
+try:  # pragma: no cover - optional dependency
+    from swiftshadow.classes import ProxyInterface  # type: ignore
+except Exception:  # pragma: no cover - swiftshadow not installed
+    ProxyInterface = None  # type: ignore
 
 
 def _iter_from_file(path: str | pathlib.Path) -> list[str]:
@@ -19,15 +28,87 @@ def _iter_from_file(path: str | pathlib.Path) -> list[str]:
     return [ln.strip() for ln in lines if ln.strip()]
 
 
+def _running_loop() -> bool:
+    try:
+        return asyncio.get_running_loop().is_running()
+    except RuntimeError:
+        return False
+
+
+def _in_thread(fn):
+    result: list[str] = []
+
+    def _wrap() -> None:
+        nonlocal result
+        result = fn()
+
+    t = Thread(target=_wrap)
+    t.start()
+    t.join()
+    return result
+
+
 def pool(
     single: Optional[str] = None,
     csv: Optional[str] = None,
     list_file: Optional[str | pathlib.Path] = None,
+    *,
+    public_proxy: int | None = None,
+    public_proxy_country: str | None = None,
+    public_proxy_type: str | None = None,
 ) -> Iterator[str | None]:
+    proxies: list[str] = []
+
     if single:
-        return itertools.cycle([single])
+        proxies.append(single)
     if csv:
-        return itertools.cycle([p.strip() for p in csv.split(",") if p.strip()])
+        proxies.extend(p.strip() for p in csv.split(",") if p.strip())
     if list_file:
-        return itertools.cycle(_iter_from_file(list_file))
-    return itertools.cycle([None])
+        proxies.extend(_iter_from_file(list_file))
+
+    if public_proxy is not None:
+        countries: list[str] = []
+        if public_proxy_country:
+            countries = [c.strip().upper() for c in public_proxy_country.split(',') if c.strip()]
+
+        if public_proxy_type is None:
+            if ProxyInterface is None:
+                public_proxy_type = "socks"
+            else:
+                public_proxy_type = choice(["http", "https"])
+        elif public_proxy_type in {"http", "https"} and ProxyInterface is None:
+            public_proxy_type = "socks"
+
+        if public_proxy_type == "socks":
+            try:
+                resp = requests.get(
+                    "https://raw.githubusercontent.com/TheSpeedX/SOCKS-List/master/socks5.txt",
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                lines = [ln.strip() for ln in resp.text.splitlines() if ln.strip()]
+                proxies.extend(f"socks5://{ln}" for ln in lines[:public_proxy])
+            except Exception:
+                pass
+        else:
+            if ProxyInterface is not None:
+                def _fetch() -> list[str]:
+                    mgr = ProxyInterface(
+                        countries=countries,
+                        protocol=public_proxy_type,
+                        maxProxies=public_proxy,
+                    )
+                    return [p.as_string() for p in mgr.proxies]
+
+                try:
+                    if _running_loop():
+                        proxies.extend(_in_thread(_fetch))
+                    else:
+                        proxies.extend(_fetch())
+                except Exception:
+                    pass
+
+    if not proxies:
+        proxies.append(None)
+
+    return itertools.cycle(proxies)

--- a/packages/site_downloader/tests/unit/test_proxy_pool.py
+++ b/packages/site_downloader/tests/unit/test_proxy_pool.py
@@ -28,3 +28,91 @@ def test_no_proxies():
     rot = pool()
     assert next(rot) is None
     assert next(rot) is None  # Should keep returning None
+
+
+def test_combined_sources(tmp_path):
+    """Proxies from single, CSV and file should all be used."""
+    proxy_file = tmp_path / "proxies.txt"
+    proxy_file.write_text("http://p3:8080\nhttp://p4:8080\n")
+
+    rot = pool(
+        single="http://p1:8080",
+        csv="http://p2:8080",
+        list_file=proxy_file,
+    )
+
+    assert [next(rot) for _ in range(5)] == [
+        "http://p1:8080",
+        "http://p2:8080",
+        "http://p3:8080",
+        "http://p4:8080",
+        "http://p1:8080",
+    ]
+
+
+def test_public_proxy_swiftshadow(monkeypatch):
+    """Public proxies are appended when Swiftshadow is available."""
+    called = {}
+
+    class _PI:
+        def __init__(self, *a, **k):
+            called.update(k)
+            self.proxies = [type("_P", (), {"as_string": lambda _: "http://pub"})()]
+
+    monkeypatch.setattr("site_downloader.proxy.ProxyInterface", _PI)
+
+    rot = pool(public_proxy=1, public_proxy_type="http")
+
+    assert called["protocol"] == "http"
+    assert list(next(rot) for _ in range(2)) == ["http://pub", "http://pub"]
+
+
+def test_public_proxy_no_swiftshadow(monkeypatch):
+    """Fallback to SOCKS list when Swiftshadow missing."""
+
+    class FakeResp:
+        status_code = 200
+        text = "1.1.1.1:1080"
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr("site_downloader.proxy.ProxyInterface", None)
+    monkeypatch.setattr(
+        "site_downloader.proxy.requests.get", lambda *a, **k: FakeResp()
+    )
+
+    rot = pool(public_proxy=1, public_proxy_type="https")
+
+    assert next(rot).startswith("socks5://1.1.1.1:1080")
+
+
+def test_swiftshadow_running_loop(monkeypatch):
+    """Swiftshadow runs in a thread when an event loop is active."""
+
+    class _PI:
+        def __init__(self, *a, **k):
+            self.proxies = [type("_P", (), {"as_string": lambda _: "http://pub"})()]
+
+    # Pretend an event loop is already running
+    class _Loop:
+        def is_running(self):
+            return True
+
+    class DummyThread:
+        def __init__(self, target):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        def join(self):
+            pass
+
+    monkeypatch.setattr("site_downloader.proxy.ProxyInterface", _PI)
+    monkeypatch.setattr("asyncio.get_running_loop", lambda: _Loop())
+    monkeypatch.setattr("site_downloader.proxy.Thread", DummyThread)
+
+    rot = pool(public_proxy=1, public_proxy_type="http")
+
+    assert next(rot) == "http://pub"


### PR DESCRIPTION
## Summary
- add Swiftshadow-based public proxy integration for `site_downloader`
- include new public proxy CLI options
- document the new options in the README
- extend proxy pool logic and tests for public proxies
- run Swiftshadow in a background thread when an event loop is active
- depend on `requests[socks]` for SOCKS proxy support

## Testing
- `./scripts/test-sd packages/site_downloader/tests/unit/test_proxy_pool.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686c8f39f378832d9bbff9d38fd07f6d