### PR TITLE
Fix swiftshadow logging and async proxy fetch

### DIFF
--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -741,7 +741,8 @@ async def _main() -> None:
                 logging.error("Swiftshadow not installed")
             else:
                 try:
-                    mgr = ProxyInterface(
+                    mgr = await asyncio.to_thread(
+                        ProxyInterface,
                         countries=countries,
                         protocol=args.public_proxy_type,
                         maxProxies=args.public_proxy,
@@ -925,7 +926,7 @@ async def _main() -> None:
         sys.stdout.flush()
         # Emit the roll-up *after* the lists.
         logging.info(
-            "Summary: ✓ %s   •  ↯ no-caption %s   •  ⚠ failed %s   •  🚫 banned %s   (total %s)",
+            "Summary: ✓ %s   •  ↯ no-caption %s   •  ⚠ failed %s   •  🚫 proxies banned %s   (total %s)",
             len(ok), len(none), len(fail), len(banned_proxies), len(ok) + len(none) + len(fail),
         )
         # plain echo guarantees the final line is literally "Summary: …"
@@ -933,9 +934,12 @@ async def _main() -> None:
             f"Summary: ✓ {C.GRN}{len(ok)}{C.END}   •  "
             f"↯ no-caption {C.YEL}{len(none)}{C.END}   •  "
             f"⚠ failed {C.RED}{len(fail)}{C.END}   "
-            f"🚫 banned {C.RED}{len(banned_proxies)}{C.END}   "
+            f"🚫 proxies banned {C.RED}{len(banned_proxies)}{C.END}   "
             f"(total {len(ok)+len(none)+len(fail)})"
         )
+        if banned_proxies:
+            logging.info("Banned proxies: %s", ", ".join(sorted(banned_proxies)))
+            print(f"Banned proxies: {', '.join(sorted(banned_proxies))}")
         sys.stdout.flush()
 
     # --------------- concatenation / splitting ------------------------

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -746,7 +746,9 @@ async def _main() -> None:
                         countries=countries,
                         protocol=args.public_proxy_type,
                         maxProxies=args.public_proxy,
+                        autoUpdate=False,
                     )
+                    await mgr.async_update()
                     public = [p.as_string() for p in mgr.proxies]
                     proxies.extend(public)
                     logging.info(

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -67,6 +67,7 @@ try:
     _slog = logging.getLogger("swiftshadow")
     _slog.handlers.clear()
     _slog.propagate = True
+    _slog.setLevel(logging.DEBUG)
 except Exception:  # pragma: no cover - optional dep
     ProxyInterface = None  # type: ignore
 # ------------------------------------------------------------
@@ -683,6 +684,7 @@ async def _main() -> None:
     logging.basicConfig(
         level=root_logger_level,
         handlers=[console_handler] + ([file_handler] if file_handler else []),
+        force=True,
     )
 
     # ---------- runtime tweaks ----------------------------------------
@@ -743,9 +745,7 @@ async def _main() -> None:
                         countries=countries,
                         protocol=args.public_proxy_type,
                         maxProxies=args.public_proxy,
-                        autoUpdate=False,
                     )
-                    await mgr.async_update()
                     public = [p.as_string() for p in mgr.proxies]
                     proxies.extend(public)
                     logging.info(

--- a/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/yt_bulk_cc.py
@@ -62,6 +62,11 @@ from .formatters import TimeStampedText, FMT, EXT
 from .converter import convert_existing
 try:
     from swiftshadow.classes import ProxyInterface
+    # Prevent Swiftshadow from writing directly to stdout so it doesn't
+    # corrupt the Rich progress bar. Instead, propagate to our root logger.
+    _slog = logging.getLogger("swiftshadow")
+    _slog.handlers.clear()
+    _slog.propagate = True
 except Exception:  # pragma: no cover - optional dep
     ProxyInterface = None  # type: ignore
 # ------------------------------------------------------------
@@ -738,7 +743,9 @@ async def _main() -> None:
                         countries=countries,
                         protocol=args.public_proxy_type,
                         maxProxies=args.public_proxy,
+                        autoUpdate=False,
                     )
+                    await mgr.async_update()
                     public = [p.as_string() for p in mgr.proxies]
                     proxies.extend(public)
                     logging.info(

--- a/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
+++ b/packages/yt_bulk_cc/tests/test_yt_bulk_cc.py
@@ -853,7 +853,7 @@ def test_check_ip_bails(monkeypatch, tmp_path: Path, capsys):
     out = _strip_ansi(capsys.readouterr().out)
     assert "Summary:" in out
     assert "failed 2" in out
-    assert "banned 1" in out
+    assert "proxies banned 1" in out
 
 
 @pytest.mark.usefixtures("patch_scrapetube", "patch_detect")
@@ -1131,7 +1131,7 @@ def test_proxy_file_rotation(monkeypatch, tmp_path: Path, capsys):
     assert captured["pool"] == ["http://cli", "http://f1", "http://f2"]
     assert used[:2] == ["http://cli", "http://f1"]
     out = _strip_ansi(capsys.readouterr().out)
-    assert "banned 1" in out
+    assert "proxies banned 1" in out
 
 
 @pytest.mark.usefixtures("patch_scrapetube", "patch_detect")


### PR DESCRIPTION
## Summary
- ensure swiftshadow logs propagate to yt_bulk_cc handlers
- use async update for swiftshadow public proxies

## Testing
- `./scripts/test-ybc -k test_public_proxy_https -vv`
- `./scripts/test-ybc -k test_no_caption_flow -vv`

------
https://chatgpt.com/codex/tasks/task_e_686d355aa364832d83e80cebb2f4365a