### PR TITLE
Fix public proxy limit handling

### DIFF
--- a/packages/yt_bulk_cc/src/yt_bulk_cc/cli.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/cli.py
@@ -431,7 +431,7 @@ async def _main() -> None:
                         await mgr.async_update()
                     elif hasattr(mgr, "update"):
                         mgr.update()
-                    public = [p.as_string() for p in mgr.proxies]
+                    public = [p.as_string() for p in mgr.proxies][: args.public_proxy]
                     proxies.extend(public)
                     logging.info(
                         "Loaded %d public %s proxies via Swiftshadow",

--- a/packages/yt_bulk_cc/tests/e2e/test_real_fetch.py
+++ b/packages/yt_bulk_cc/tests/e2e/test_real_fetch.py
@@ -1,4 +1,5 @@
 import urllib.request
+import requests
 import asyncio
 from pathlib import Path
 import sys
@@ -9,15 +10,17 @@ from yt_bulk_cc import yt_bulk_cc as ytb
 pytestmark = pytest.mark.e2e
 
 try:
-    urllib.request.urlopen('https://www.youtube.com', timeout=5)
+    resp = requests.get("https://www.youtube.com", timeout=5)
+    if resp.status_code >= 400:
+        raise RuntimeError(resp.status_code)
 except Exception:
-    pytest.skip('YouTube unreachable', allow_module_level=True)
+    pytest.skip("YouTube unreachable", allow_module_level=True)
 
 
 def run_cli(tmp_path: Path, *argv: str) -> None:
-    sys.argv[:] = ['yt_bulk_cc.py', *argv]
-    if '-o' not in argv and '--folder' not in argv:
-        sys.argv += ['-o', str(tmp_path)]
+    sys.argv[:] = ["yt_bulk_cc.py", *argv]
+    if "-o" not in argv and "--folder" not in argv:
+        sys.argv += ["-o", str(tmp_path)]
     try:
         asyncio.run(ytb.main())
     except SystemExit as e:
@@ -26,31 +29,36 @@ def run_cli(tmp_path: Path, *argv: str) -> None:
 
 
 def test_real_playlist(tmp_path: Path):
-    playlist = 'https://www.youtube.com/playlist?list=PLQut38RVINETzTudtKaSVIUxOizsFXfYB'
-    run_cli(tmp_path, playlist, '-n', '1')
-    assert list(tmp_path.glob('*.json'))
+    playlist = (
+        "https://www.youtube.com/playlist?list=PLQut38RVINETzTudtKaSVIUxOizsFXfYB"
+    )
+    run_cli(tmp_path, playlist, "-n", "1")
+    assert list(tmp_path.glob("*.json"))
 
 
 def test_real_channel(tmp_path: Path):
-    channel = 'https://www.youtube.com/@miroska-tv'
-    run_cli(tmp_path, channel, '-n', '1')
-    assert list(tmp_path.glob('*.json'))
+    channel = "https://www.youtube.com/@miroska-tv"
+    run_cli(tmp_path, channel, "-n", "1")
+    assert list(tmp_path.glob("*.json"))
 
 
 def test_real_playlist_with_limit(tmp_path: Path):
-    playlist = 'https://www.youtube.com/playlist?list=PLQut38RVINETzTudtKaSVIUxOizsFXfYB'
-    run_cli(tmp_path, playlist, '-n', '2')
-    json_files = list(tmp_path.glob('*.json'))
+    playlist = (
+        "https://www.youtube.com/playlist?list=PLQut38RVINETzTudtKaSVIUxOizsFXfYB"
+    )
+    run_cli(tmp_path, playlist, "-n", "2")
+    json_files = list(tmp_path.glob("*.json"))
     assert json_files
 
 
 def test_real_channel_with_limit(tmp_path: Path):
-    channel = 'https://www.youtube.com/@miroska-tv'
-    run_cli(tmp_path, channel, '-n', '3')
-    json_files = list(tmp_path.glob('*.json'))
+    channel = "https://www.youtube.com/@miroska-tv"
+    run_cli(tmp_path, channel, "-n", "3")
+    json_files = list(tmp_path.glob("*.json"))
     assert json_files
 
+
 def test_real_video(tmp_path: Path):
-    video = 'https://www.youtube.com/watch?v=BhT-lN4mqqU'
+    video = "https://www.youtube.com/watch?v=BhT-lN4mqqU"
     run_cli(tmp_path, video)
-    assert list(tmp_path.glob('*.json'))
+    assert list(tmp_path.glob("*.json"))


### PR DESCRIPTION
## Summary
- limit public proxies to the requested count
- skip real-fetch tests when YouTube is unreachable using a stricter check
- cover proxy limiting logic with a new unit test

## Testing
- `ruff check packages/yt_bulk_cc/src/yt_bulk_cc/cli.py packages/yt_bulk_cc/tests/e2e/test_real_fetch.py packages/yt_bulk_cc/tests/unit/test_proxy.py`
- `black packages/yt_bulk_cc/tests/e2e/test_real_fetch.py packages/yt_bulk_cc/src/yt_bulk_cc/cli.py packages/yt_bulk_cc/tests/unit/test_proxy.py`
- `./scripts/test-ybc packages/yt_bulk_cc/tests/unit/test_proxy.py::test_public_proxy_limit -vv`

------
https://chatgpt.com/codex/tasks/task_e_687a6c882ef4832d9fc88e6996d7b33d