### PR TITLE
Fix proxy validation abort and add test

### DIFF
--- a/packages/yt_bulk_cc/src/yt_bulk_cc/cli.py
+++ b/packages/yt_bulk_cc/src/yt_bulk_cc/cli.py
@@ -468,10 +468,15 @@ async def _main() -> None:
                 results = [f.result() for f in concurrent.futures.as_completed(futures)]
             proxies_valid = [p for p in results if p]
             if not proxies_valid:
-                logging.error("No valid public proxies for HTTPS/YouTube. Aborting.")
-                sys.exit(2)
-            proxies = [p for p in proxies if p in proxies_valid]
-            logging.info("%d public proxies validated for HTTPS/YouTube", len(proxies_valid))
+                logging.warning(
+                    "Public proxies could not be validated; proceeding without validation."
+                )
+            else:
+                proxies = [p for p in proxies if p in proxies_valid]
+                logging.info(
+                    "%d public proxies validated for HTTPS/YouTube",
+                    len(proxies_valid),
+                )
     public_count = len(public) if args.public_proxy is not None else 0
     proxy_cycle = None
     if proxies:


### PR DESCRIPTION
## Summary
- avoid aborting when validating public proxies fails
- test that the CLI continues if proxy validation errors occur

## Testing
- `./scripts/test-ybc`

------
https://chatgpt.com/codex/tasks/task_e_687a997fbe18832d96846b2f235368a5