### PR TITLE
Improve Markdown conversion logic with MarkItDown

### DIFF
--- a/packages/site_downloader/tests/unit/test_convert_html.py
+++ b/packages/site_downloader/tests/unit/test_convert_html.py
@@ -9,3 +9,32 @@ HTML = "<h1>Title</h1><p><b>bold</b> and <i>italic</i></p>"
 def test_text_conversions(fmt):
     out = convert_html(HTML, fmt)
     assert isinstance(out, str) and len(out) > 10
+
+
+def test_markitdown_path(monkeypatch):
+    class DummyResult:
+        text_content = "ok"
+
+    class DummyMD:
+        def convert_stream(self, *args, **kwargs):
+            return DummyResult()
+
+    monkeypatch.setattr("site_downloader.convert.MarkItDown", lambda: DummyMD())
+    monkeypatch.setattr("site_downloader.convert._MARKITDOWN_AVAILABLE", True)
+    out = convert_html(HTML, "md")
+    assert out == "ok"
+
+
+def test_markdownify_fallback(monkeypatch):
+    calls = {}
+
+    def fake_mdify(html, *, heading_style="ATX"):
+        calls["html"] = html
+        calls["style"] = heading_style
+        return "fallback"
+
+    monkeypatch.setattr("site_downloader.convert._MARKITDOWN_AVAILABLE", False)
+    monkeypatch.setattr("site_downloader.convert.mdify", fake_mdify)
+    out = convert_html(HTML, "md")
+    assert out == "fallback"
+    assert calls["style"] == "ATX"


### PR DESCRIPTION
## Summary
- use MarkItDown API in `convert_html`
- fall back to markdownify when MarkItDown fails
- add tests covering MarkItDown path and fallback

## Testing
- `./scripts/test-sd` *(fails: 12 failed, 55 passed, 7 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687bd1e92cb8832d82fe2c5a32247d29